### PR TITLE
Use new PTX theme

### DIFF
--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -10,7 +10,7 @@
     </source>
     <html>
       <knowl exercise-inline="no" example="no" listing="yes" />
-      <css style="oscarlevin" colors="blue_red" toc="crc" banner="crc" navbar="crc" shell="crc"/>
+      <css theme="default-modern"/>
       <search variant="default" />
     </html>
     <numbering>


### PR DESCRIPTION
I noticed that some things are starting to look broken with the old PTX CSS (e.g. the copy code button that appears on any listing).
<img width="750" height="107" alt="image" src="https://github.com/user-attachments/assets/869d7c4e-045d-4cf9-a9c3-9dbe1169e3f5" />

Time to switch to a modern theme?