### PR TITLE
Lti1p3 doc improvements

### DIFF
--- a/pretext/Registration/lti1p3.ptx
+++ b/pretext/Registration/lti1p3.ptx
@@ -11,7 +11,7 @@
             </p>
         </note>
         <p>
-            Runestone's LTI 1.3 integration has been tested against Canvas and Moodle. Others LMS systems that support LTI 1.3 may or may not work. We welcome reports of successful use with other LMS systems and code pull requests to add any necessary support for other LMS systems. Community driven support is available on the <c>#lti_community_support</c> channel of the <url href="https://discord.com/channels/1013815439161315348/1023237792697954324" visual="Runestone Discord Server">Runestone Discord Server</url>.
+            Runestone's LTI 1.3 integration has been tested against Canvas, Moodle, and D2L. Others LMS systems that support LTI 1.3 may or may not work. We welcome reports of successful use with other LMS systems and code pull requests to add any necessary support for other LMS systems. Community driven support is available on the <c>#lti_community_support</c> channel of the <url href="https://discord.com/channels/1013815439161315348/1023237792697954324" visual="Runestone Discord Server">Runestone Discord Server</url>.
         </p>
     </subsection>
     <subsection>
@@ -35,7 +35,7 @@
             </p>
 
             <p>
-                Runestone supports the LTI Dynamic Registration protocol. This means you will just need to enter one URL into your LMS and the two systems will negotiate the rest of the details:
+                Runestone supports the LTI Dynamic Registration protocol. (We do not support manual registration of LTI 1.3 tools via manual key exchange.) This means you will just need to enter one URL into your LMS and the two systems will negotiate the rest of the details:
             </p>
 
             <note xml:id="lti1p3-registration-url">
@@ -152,37 +152,39 @@
     <subsection  xml:id="lti1p3-instructor-setup">
         <title>LTI1.3 Setup - Instructor</title>
 
-        <warning>
-            <p>To use LTI 1.3 integration with a course, the domain of your LMS must be approved by a Runestone administrator. If your institution required Runestone to complete any paperwork as part of the setup of Runestone as an LTI 1.3 tool, this should already be complete. If your institution did not contact Runestone during setup, you will need to make a request for approval. You can do so <url href="https://github.com/RunestoneInteractive/rs/issues"> by making a new issue on the Runestone github page</url>. Select <term>Request for LTI 1.3 Approval</term> as the issue type and make sure to specify your contact information, and the domain your LMS runs on.</p>
-        </warning>
+        <introduction>
+            <warning>
+                <p>To use LTI 1.3 integration with a course, the domain of your LMS must be approved by a Runestone administrator. If your institution required Runestone to complete any paperwork as part of the setup of Runestone as an LTI 1.3 tool, this should already be complete. If your institution did not contact Runestone during setup, you will need to make a request for approval. You can do so <url href="https://github.com/RunestoneInteractive/rs/issues"> by making a new issue on the Runestone github page</url>. Select <term>Request for LTI 1.3 Approval</term> as the issue type and make sure to specify your contact information, and the domain your LMS runs on.</p>
+            </warning>
 
-        <p>
-            First make sure that you have a Runestone account. If you don't have one, you can create one at <url href="https://runestone.academy">Runestone Academy</url>. Create a Runestone course to link to your LMS course. You may also wish to set up assignments in Runestone at this point, although you can always link new ones later. Before you try to link your LMS to a course and/or assignments, you should make sure you are logged into Runestone and currently viewing the course you want to link to.
-        </p>
+            <p>
+                First make sure that you have a Runestone account. If you don't have one, you can create one at <url href="https://runestone.academy">Runestone Academy</url>. Create a Runestone course to link to your LMS course. You may also wish to set up assignments in Runestone at this point, although you can always link new ones later. Before you try to link your LMS to a course and/or assignments, you should make sure you are logged into Runestone and currently viewing the course you want to link to.
+            </p>
 
-        <p>
-            Depending on how your LMS reports your identity to Runestone, when you access Runestone from the LMS by clicking a link to your RS course or book, you may or may not be logged into Runestone as the same user as the account you created. (If your LMS reports your email, and you set up your RS account with the same email, then you should be logged in as the same user.) If you end up with a different identity in Runestone, you will likely want to add that user as an instructor. You can do this by adding the user as a <q>TA</q>. See <xref ref="add_instructor" /> for more information.
-        </p>
+            <p>
+                Depending on how your LMS reports your identity to Runestone, when you access Runestone from the LMS by clicking a link to your RS course or book, you may or may not be logged into Runestone as the same user as the account you created. (If your LMS reports your email, and you set up your RS account with the same email, then you should be logged in as the same user.) If you end up with a different identity in Runestone, you will likely want to add that user as an instructor. You can do this by adding the user as a <q>TA</q>. See <xref ref="add_instructor" /> for more information.
+            </p>
 
-        <p>
-            Each RS course can be linked to only one LMS course. This means that if you have multiple <q>courses</q> in your LMS for multiple sections or some other reason, you will need to create different RS courses for each LMS course. You can link multiple RS courses to the same LMS course (if you are using multiple books in one course.) If you need to unlink Runestone from an LMS, you can use the <term>Remote LTI 1.3 Association</term> button from the <term>Admin > LTI Integration</term> screen. Doing so will NOT remove any assignments or grades from the LMS, but it will prevent new grades from being sent to the LMS. You can then relink the course with the same LMS course or a new one.
-        </p>
-        
-        <p>There are some settings available in each Runestone course that affect LTI integration:
-        <ul>
-            <li>Under <term>Admin > Course Settings</term>, <term>Show Points in Gradebook</term> will affect how scores are reported to the LMS. If you want assignments reported to the LMS as points (3 / 4) instead of percent (75%), make sure this is checked. Note that settings in your LMS grade book may allow you to weight scores or change their display in other ways that override the way Runestone reports them to the LMS.</li>
-            <li>Under <term>Admin > LTI Integration</term>, checking <term>Ignore LTI1.3 Date Changes</term> will prevent Runestone from updating due dates on assignments.</li>
-            <li>Under <term>Admin > LTI Integration</term>, checking <term>Do not auto update LTI grades</term> will prevent Runestone from trying to automatically send grade updates as a user completes activities. This may be desirable if your assignments contain lots of items that need to be hand graded and you do not want users to see misleading low grades for assignments that have not been fully scored yet.</li>
-        </ul>
-        </p>
-
-        <p>Find the subsection below for details on how to add Runestone to your course:
+            <p>
+                Each RS course can be linked to only one LMS course. This means that if you have multiple <q>courses</q> in your LMS for multiple sections or some other reason, you will need to create different RS courses for each LMS course. You can link multiple RS courses to the same LMS course (if you are using multiple books in one course.) If you need to unlink Runestone from an LMS, you can use the <term>Remote LTI 1.3 Association</term> button from the <term>Admin > LTI Integration</term> screen. Doing so will NOT remove any assignments or grades from the LMS, but it will prevent new grades from being sent to the LMS. You can then relink the course with the same LMS course or a new one.
+            </p>
+            
+            <p>There are some settings available in each Runestone course that affect LTI integration:
             <ul>
-                <li><xref ref="lti1p3-lms-instructor-setup-canvas" text="title"/></li>
-                <li><xref ref="lti1p3-lms-instructor-setup-moodle" text="title"/></li>
-                <li><xref ref="lti1p3-lms-instructor-setup-D2L" text="title"/></li>
+                <li>Under <term>Admin > Course Settings</term>, <term>Show Points in Gradebook</term> will affect how scores are reported to the LMS. If you want assignments reported to the LMS as points (3 / 4) instead of percent (75%), make sure this is checked. Note that settings in your LMS grade book may allow you to weight scores or change their display in other ways that override the way Runestone reports them to the LMS.</li>
+                <li>Under <term>Admin > LTI Integration</term>, checking <term>Ignore LTI1.3 Date Changes</term> will prevent Runestone from updating due dates on assignments.</li>
+                <li>Under <term>Admin > LTI Integration</term>, checking <term>Do not auto update LTI grades</term> will prevent Runestone from trying to automatically send grade updates as a user completes activities. This may be desirable if your assignments contain lots of items that need to be hand graded and you do not want users to see misleading low grades for assignments that have not been fully scored yet.</li>
             </ul>
-        </p>
+            </p>
+
+            <p>Find the subsection below for details on how to add Runestone to your course:
+                <ul>
+	                <li><xref ref="lti1p3-lms-instructor-setup-canvas" text="title"/></li>
+	                <li><xref ref="lti1p3-lms-instructor-setup-moodle" text="title"/></li>
+	                <li><xref ref="lti1p3-lms-instructor-setup-D2L" text="title"/></li>
+                </ul>
+            </p>
+        </introduction>
 
         <subsubsection  xml:id="lti1p3-lms-instructor-setup-canvas">
             <title>LTI 1.3 Instructor Setup - Canvas</title>
@@ -272,8 +274,8 @@
         </subsubsection>
 
         <subsubsection>
-            <title>LTI1.3 Grade Reporting</title>
-            <p>Grades are normally sent to Runestone at the following times:
+            <title>Grade Reporting</title>
+            <p>Grades are normally sent by Runestone to the LMS at the following times:
                 <ul>
                     <li>A learner interacts with any graded element of the course that is part of an active assignment with released grades. (Grade updates should happen whether the user is viewing the problem <q>in context</q> or in the assignment view).</li>
                     <li>The instructor goes to the <term>Grading</term> tab of the admin interface, selects an <term>assignment</term> and presses the <term>Push Grades to LTI</term> button. This will send score updates for that assignment for all users in the course regardless of whether or not scores are released in Runestone.</li>
@@ -283,30 +285,58 @@
             </p>
         </subsubsection>
 
+        <subsubsection>
+            <title>Date Syncing</title>
+            <p>Your LMS is considered the authority on due dates. By default, Runestone assignments will update their due dates to match the LMS. To disable this behavior, you can check the <term>Ignore LTI1.3 Date Changes</term> box in the <term>Admin > LTI Integration</term> settings for your course. (Automatically syncing from Runestone to the LMS is not an option.)</p>
+            <p>Syncing behavior:
+                <ul>
+                    <li>When you create a new assignment in your LMS by linking to a Runestone assignment, the due date in your LMS will be set to the due date in Runestone.</li>
+                    <li>When linking an existing LMS assignment to a Runestone assignment, the due date in Runestone will be updated to match the due date in the LMS (unless you have checked the <term>Ignore LTI1.3 Date Changes</term>).</li>
+                    <li>When an assignment's due date is changed in the LMS, the due date in Runestone will be updated to match (unless you have checked the <term>Ignore LTI1.3 Date Changes</term>). This will not happen until a user (instructor or student) uses the assignment link in the LMS to launch the assignment in Runestone. So, to force an update after modifying a due date, open the assignment.</li>
+                </ul>
+            </p>
+        </subsubsection>
+
         <subsubsection xml:id="lti1p3_copy">
             <title>Copying an LTI1.3 Course</title>
             <p>
                 To reuse course content that you linked in one course for a new course, you will generally want to do the following:
                 <ol>
                     <li>
-                        Use your LMS to copy the assignments from your old course to your new course. They will not be linked to Runestone. If  you want to synchronize the due dates automatically, use your LMS to set up due dates.
+                        Use your LMS to copy the assignments from your old course to your new course. They will not be linked to Runestone.
                     </li>
                     <li>
                         In Runestone, make a new course. Copy all of the assignments from your old course to your new course. If you want to make sure the due dates are synced, do not check the <term>Ignore LTI1.3 Date Changes</term> box in the <term>Admin > LTI Integration</term> settings for your new course before finishing the linking process.
                     </li>
+                    <li><p>
+                            Do you want to have due dates in Runestone set to match those in your LMS for the copied assignments?
+                            <ul>
+                                <li>
+                                    <p>If <em>Yes</em>, make sure the <term>Ignore LTI1.3 Date Changes</term> is <em>not</em> checked. (Should be the default)</p>
+                                    <p>Then, set up due dates in the LMS before linking the assignments.</p>
+                                </li>
+                                <li>If <em>No</em>, check the <term>Ignore LTI1.3 Date Changes</term> box in the <term>Admin > LTI Integration</term> settings for your new course.</li>
+                            </ul>
+                        </p>
+                    </li>
                     <li>
-                        In your LMS, use the add content feature and select the Runestone tool. Assuming your assignments in the two platforms have matching names, the default actions suggested for each RS assignment will be to link to the existing LMS assignment with the same name. If there is a mismatch, change the LMS assignment name to match the RS assignment name before linking. When you submit the form, the assignments will be linked and the due dates from the LMS will be synced to Runestone.
+                        Assignments in Runestone and the LMS will be matched by name. If the assignment names do not match, change the name(s) on either platform so corresponding assignments are identically named.
+                    </li>
+                    <li>
+                        <p>Now you are ready to link the copies on the two platforms. Make sure you are still logged into the new course in Runestone as you complete the linking.</p>
+                        <p>In your LMS, use the add content feature and select the Runestone tool. Assuming your assignments in the two platforms have matching names, the default actions suggested for each RS assignment will be to link to the existing LMS assignment with the same name.</p> 
+                        <p>Submit the form to complete the linking process. You may get a message like <q>Tool returned no content</q> as there were no new assignments sent from Runestone back to the LMS. But, the selected assignments should now be linked. Click one to verify.</p>
                     </li>
                 </ol>
             </p>
         </subsubsection>
         <subsubsection>
-            <title>LTI 1.3 Canvas Notes</title>
+            <title>Canvas Notes for LTI 1.3</title>
             <p>The best way to create new content items (especially multiple at one time) is in the <term>Modules</term> area. Use the three dot menu and select Runestone.</p>
             <image source="Figures/canvas-lti1p3-module-use.jpg" alt="Adding Runestone items from the Canvas Module area" />
         </subsubsection>
         <subsubsection>
-            <title>LTI 1.3 Moodle Notes</title>
+            <title>Moodle Notes for LTI 1.3</title>
             <p>To add content items, use one of the <term>Add an activity or resource</term> links in your course. Select <term>Runestone</term> from the available tools. You will be taken to a form adding one activity, but you can still add as many Runestone links as you like. Click the <term>Select content</term> button. When you finish selecting content, if you selected just one new RS item, you will return to the form to finish editing that activity and save it in your LMS. If you selected multiple items, you will return to a page that lists the items being added. If your actions do not add any new content (you are remapping copied assignments), you will be returned to a blank form but Runestone will have updated your selected items.</p>
             <image source="Figures/moodle-lti1p3-selectcontent-use.jpg" alt="Adding Runestone items from the Moodle Select content area" />
         </subsubsection>

--- a/publication/publication-academy.ptx
+++ b/publication/publication-academy.ptx
@@ -2,7 +2,8 @@
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
     <common>
-        <chunking level="1" />
+        <chunking level="2" />
+        <tableofcontents level="4" />
     </common>
     <source>
         <directories external="../assets" generated="../generated-assets"/>

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -2,7 +2,7 @@
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
     <common>
-    <chunking level="1" />
+    <chunking level="2" />
     <tableofcontents level="4" />
     </common>
     <source>


### PR DESCRIPTION
Expands ToC depth to make navigating in subsections easier
Improve LTI1p3 course copy instructions
Consolidate date syncing documentation
Document no manual key exchange setup option